### PR TITLE
Fixed  secadd_constant and secadd_constant_bmsk in gadgets.c

### DIFF
--- a/crypto_sign/dilithium3/m4f_masked/gadgets.c
+++ b/crypto_sign/dilithium3/m4f_masked/gadgets.c
@@ -176,7 +176,7 @@ void secadd_constant_bmsk(size_t nshares, size_t kbits, size_t kbits_out,
     } else {
       // compute the carry
       masked_xor(nshares, &out[i * out_data_stride], out_msk_stride, carry, 1,
-                 &in1[i * in1_data_stride], 1);
+                 &in1[i * in1_data_stride], in1_msk_stride);
 
       if ((i == (kbits - 1)) && (i == (kbits_out - 1))) {
         return;
@@ -245,7 +245,7 @@ void secadd_constant(size_t nshares, size_t kbits, size_t kbits_out,
     } else {
       // compute the carry
       masked_xor(nshares, &out[i * out_data_stride], out_msk_stride, carry, 1,
-                 &in1[i * in1_data_stride], 1);
+                 &in1[i * in1_data_stride], in1_msk_stride);
 
       if ((i == (kbits - 1)) && (i == (kbits_out - 1))) {
         return;


### PR DESCRIPTION
There is a bug in secadd const gadgets, where the wrong masking stride was used for the input. Thank you for the much appreciated gadgets.